### PR TITLE
Remove the obsolete sedis maven repo.

### DIFF
--- a/spark-benchmarks/pom.xml
+++ b/spark-benchmarks/pom.xml
@@ -15,13 +15,6 @@
 
     <artifactId>spark-benchmarks</artifactId>
 
-    <repositories>
-        <repository>
-            <id>org.sedis</id>
-            <url>http://pk11-scratch.googlecode.com/svn/trunk</url>
-        </repository>
-    </repositories>
-
     <dependencies>
         <dependency>
             <groupId>org.json</groupId>


### PR DESCRIPTION
The sedis project has been migrated to maven central, the googlecode repo is obsolete.